### PR TITLE
Bump org.springframework.boot til 3.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.springframework.boot") version "3.3.5"
+    id("org.springframework.boot") version "3.4.0"
     id("io.spring.dependency-management") version "1.1.6"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     kotlin("plugin.spring") version "2.0.21"

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/config/AadRestTemplateConfiguration.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/config/AadRestTemplateConfiguration.kt
@@ -58,7 +58,7 @@ class AadRestTemplateConfiguration {
             // https://kotlinlang.org/docs/fun-interfaces.html#sam-conversions
             .requestFactory(Supplier { HttpComponentsClientHttpRequestFactory(httpClient) })
             .additionalInterceptors(bearerTokenInterceptor(clientProperties, oAuth2AccessTokenService))
-            .setConnectTimeout(Duration.ofSeconds(PDL_REST_TEMPLATE_CONNECT_TIMEOUT))
+            .connectTimeout(Duration.ofSeconds(PDL_REST_TEMPLATE_CONNECT_TIMEOUT))
             .build()
     }
 

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/kafkaprodusering/LeaderElection.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/kafkaprodusering/LeaderElection.kt
@@ -50,7 +50,7 @@ class LeaderElection(
             val hostname: String = InetAddress.getLocalHost().hostName
 
             val uriString =
-                UriComponentsBuilder.fromHttpUrl(getHttpPath(electorPath))
+                UriComponentsBuilder.fromUriString(getHttpPath(electorPath))
                     .toUriString()
             val result =
                 plainTextUtf8RestTemplate

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/FellesTestOppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/FellesTestOppsett.kt
@@ -25,8 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.MockMvc
-import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 
 private class PostgreSQLContainer14 : PostgreSQLContainer<PostgreSQLContainer14>("postgres:14-alpine")
@@ -51,7 +51,7 @@ abstract class FellesTestOppsett {
     companion object {
         init {
 
-            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1")).also {
+            KafkaContainer(DockerImageName.parse("apache/kafka-native")).also {
                 it.start()
                 System.setProperty("KAFKA_BROKERS", it.bootstrapServers)
             }


### PR DESCRIPTION
Bruk apache/kafka-native i stedet for confluentinc/cp-kafka for mindre image og
raskere oppstart.
