### PR TITLE
Logg tilleggsopplysninger ved ventetidsberegning

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
@@ -109,6 +109,10 @@ class VentetidUtregner(
         identer: List<String>,
         ventetidRequest: VentetidRequest,
     ): FomTomPeriode? {
+        if (ventetidRequest.tilleggsopplysninger != null) {
+            log.info("Bruker tilleggsopplysninger i beregning av ventetid.")
+        }
+
         val biter =
             syketilfellebitRepository
                 .findByFnrIn(identer)


### PR DESCRIPTION
Antagelse: feltet er ikke i bruk og kan fjernes.
