### PR TITLE
Beregn korrekt ventetid for tilbakedaterte sykmeldinger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ build/
 .kotlin/
 .DS_Store
 .claude
-Claude.md
+CLAUDE.md
 

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
@@ -8,10 +8,11 @@ data class ErUtenforVentetidRequest(
     val kunSendtBekreftet: Boolean = false,
 )
 
-fun ErUtenforVentetidRequest.tilVentetidRequest(): VentetidRequest =
+fun ErUtenforVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding: Boolean = false): VentetidRequest =
     VentetidRequest(
         sykmeldingKafkaMessage = sykmeldingKafkaMessage,
         kunSendtBekreftet = kunSendtBekreftet,
+        beregnForAktuellSykmelding = beregnForAktuellSykmelding,
     )
 
 data class SammeVentetidRequest(
@@ -30,6 +31,7 @@ data class VentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
     val returnerPerioderInnenforVentetid: Boolean = false,
     val kunSendtBekreftet: Boolean = false,
+    val beregnForAktuellSykmelding: Boolean = false,
 )
 
 data class VentetidResponse(
@@ -53,6 +55,4 @@ data class SammeVentetidPeriode(
 // Brukes i TokenX-response fra flex-sykmeldinger-backend.
 data class ErUtenforVentetidResponse(
     val erUtenforVentetid: Boolean,
-    val oppfolgingsdato: LocalDate?,
-    val ventetid: FomTomPeriode? = null,
 )

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
@@ -44,24 +44,14 @@ class VentetidController(
     fun erUtenforVentetid(
         @PathVariable sykmeldingId: String,
     ): ErUtenforVentetidResponse {
-        val identer = hentIdenter(validerTokenXClaims().fnrFraIdportenTokenX())
-        val sanitertSykmeldingId = sykmeldingId.sanitizeForLog()
-
-        val erUtenforVentetid = ventetidUtregner.erUtenforVentetid(sanitertSykmeldingId, identer, ErUtenforVentetidRequest())
-        val ventetid =
-            ventetidUtregner.beregnVentetid(
-                sykmeldingId = sanitertSykmeldingId,
-                identer = identer,
-                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
+        val erUtenforVentetid =
+            ventetidUtregner.erUtenforVentetid(
+                sykmeldingId = sykmeldingId.sanitizeForLog(),
+                identer = hentIdenter(validerTokenXClaims().fnrFraIdportenTokenX()),
+                erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+                beregnForAktuellSykmelding = true,
             )
-
-        val sykeforloep = sykeforloepUtregner.hentSykeforloep(identer, inkluderPapirsykmelding = false)
-        val oppfolgingsdato =
-            sykeforloep
-                .find { it.sykmeldinger.any { sm -> sm.id == sanitertSykmeldingId } }
-                ?.oppfolgingsdato
-
-        return ErUtenforVentetidResponse(erUtenforVentetid, oppfolgingsdato, ventetid)
+        return ErUtenforVentetidResponse(erUtenforVentetid)
     }
 
     @PostMapping(value = ["/api/v1/ventetid/{sykmeldingId}/erUtenforVentetid"])

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
@@ -51,7 +51,8 @@ class VentetidUtregner(
         sykmeldingId: String,
         identer: List<String>,
         erUtenforVentetidRequest: ErUtenforVentetidRequest,
-    ): Boolean = beregnVentetid(sykmeldingId, identer, erUtenforVentetidRequest.tilVentetidRequest()) != null
+        beregnForAktuellSykmelding: Boolean = false,
+    ): Boolean = beregnVentetid(sykmeldingId, identer, erUtenforVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding)) != null
 
     fun finnPerioderMedSammeVentetid(
         sykmeldingId: String,
@@ -123,19 +124,24 @@ class VentetidUtregner(
             return null
         }
 
-        val sykmeldingSenesteTom = aktuellSykmeldingBiter.maxOf { it.tom }
-
-        val perioder =
+        // Slår sammen relevante biter til perioder uten å avgrense til den aktuelle sykmeldingens `tom` sånn at også
+        // tilbakedaterte sammenhengende perioder slått sammen med periodene til den aktuelle sykmeldingen.
+        val mergedePerioder =
             sykmeldingBiter
                 .asSequence()
                 .filter { it.tags.contains(Tag.SYKMELDING) }
                 .filter { bit -> bit.tags.any { tag -> tag in AKTIVITET_TAGS } }
                 .filterNot { bit -> bit.tags.any { it in EKSKLUDERTE_TAGS } }
                 .map { it.tilPeriode() }
-                .filter { it.fom <= sykmeldingSenesteTom }
-                .map { it.kuttBitSomErLengreEnnAktuellTom(sykmeldingSenesteTom) }
                 .toList()
                 .mergePerioder(sykmeldingId)
+
+        // Den sammenslåtte perioden som inneholder den aktuelle sykmeldingen definerer 'tom' for ventetidsberegningen.
+        val gjeldendePeriode = mergedePerioder.firstOrNull { it.ressursId == sykmeldingId } ?: return null
+
+        val perioder =
+            mergedePerioder
+                .filter { it.fom <= gjeldendePeriode.tom }
                 .fjernHelgFraSluttenAvPerioden(sykmeldingId)
 
         perioder.beregnVentetid()?.let { ventetid ->
@@ -201,7 +207,14 @@ class VentetidUtregner(
                     addAll(sykmeldingMessage.mapTilBiter())
                 }
             }.let { biter ->
-                if (ventetidRequest.kunSendtBekreftet) biter.filterNot { it.tags.contains(Tag.NY) } else biter
+                // Hvis beregnForAktuellSykmelding er true, beholdes biter med status NY kun for den aktuelle sykmeldingen.
+                // Nødvendig for å beregne ventetid riktig i flex-sykepengesoknad-backend.
+                when {
+                    !ventetidRequest.kunSendtBekreftet -> biter
+                    ventetidRequest.beregnForAktuellSykmelding ->
+                        biter.filterNot { it.tags.contains(Tag.NY) && it.ressursId != sykmeldingId }
+                    else -> biter.filterNot { it.tags.contains(Tag.NY) }
+                }
             }
 
     private fun Syketilfellebit.tilPeriode(): Periode =
@@ -212,13 +225,6 @@ class VentetidUtregner(
             ressursId = this.ressursId,
             erAnnetFravaer = this.tags.contains(Tag.ANNET_FRAVAR),
         )
-
-    private fun Periode.kuttBitSomErLengreEnnAktuellTom(sykmeldingSisteTom: LocalDate): Periode =
-        if (this.tom.isAfter(sykmeldingSisteTom)) {
-            this.copy(tom = sykmeldingSisteTom)
-        } else {
-            this
-        }
 
     private fun List<Periode>.mergePerioder(foretrukketRessursId: String): List<Periode> {
         if (size <= 1) return this

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/OverlappendePerioderTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/OverlappendePerioderTest.kt
@@ -107,7 +107,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 12)
                 }
 
             ventetidUtregner
@@ -208,7 +208,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 4)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
                 }
         }
 
@@ -253,7 +253,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 5)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
                 }
         }
 
@@ -287,7 +287,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 5)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
                 }
 
             ventetidUtregner
@@ -332,7 +332,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 4)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
                 }
 
             ventetidUtregner
@@ -433,7 +433,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 12)
                 }
         }
     }
@@ -571,7 +571,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 16)
                 }
         }
 
@@ -616,7 +616,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 12)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 16)
                 }
         }
 
@@ -650,7 +650,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 12)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 16)
                 }
 
             ventetidUtregner
@@ -695,7 +695,7 @@ class OverlappendePerioderTest : FellesTestOppsett() {
                 )!!
                 .also {
                     it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
+                    it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 16)
                 }
 
             ventetidUtregner

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidControllerTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidControllerTest.kt
@@ -124,12 +124,6 @@ class VentetidControllerTest : FellesTestOppsett() {
             sykmeldingId = melding.sykmelding.id,
         ).also {
             it.erUtenforVentetid `should be` false
-            it.oppfolgingsdato `should be equal to` LocalDate.of(2024, Month.JULY, 1)
-            it.ventetid `should be equal to`
-                FomTomPeriode(
-                    LocalDate.of(2024, Month.JULY, 1),
-                    LocalDate.of(2024, Month.JULY, 16),
-                )
         }
     }
 
@@ -147,12 +141,6 @@ class VentetidControllerTest : FellesTestOppsett() {
             sykmeldingId = melding.sykmelding.id,
         ).also {
             it.erUtenforVentetid `should be` true
-            it.oppfolgingsdato `should be equal to` LocalDate.of(2024, Month.JULY, 1)
-            it.ventetid `should be equal to`
-                FomTomPeriode(
-                    LocalDate.of(2024, Month.JULY, 1),
-                    LocalDate.of(2024, Month.JULY, 16),
-                )
         }
     }
 

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidTilbakedateringTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidTilbakedateringTest.kt
@@ -1,0 +1,246 @@
+package no.nav.helse.flex.syketilfelle.ventetid
+
+import no.nav.helse.flex.syketilfelle.FellesTestOppsett
+import no.nav.helse.flex.syketilfelle.lagBekreftetSykmeldingKafkaMessage
+import no.nav.helse.flex.syketilfelle.lagMottattSykmeldingKafkaMessage
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+import java.time.Month
+
+class VentetidTilbakedateringTest : FellesTestOppsett() {
+    @Autowired
+    private lateinit var ventetidUtregner: VentetidUtregner
+
+    @BeforeEach
+    @AfterEach
+    fun setUp() {
+        syketilfellebitRepository.deleteAll()
+    }
+
+    private val fnr = "11111111111"
+
+    @Test
+    fun `To perioder til sammen 16 dager har samme ventetid`() {
+        val melding1 =
+            lagMottattSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 8),
+            ).also { it.prosesser() }
+
+        val melding2 =
+            lagMottattSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 9),
+                tom = LocalDate.of(2026, Month.JUNE, 16),
+            ).also { it.prosesser() }
+
+        ventetidUtregner
+            .erUtenforVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding1.sykmelding.id,
+                erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+            ) `should be` false
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding1.sykmelding.id,
+                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
+            }
+
+        ventetidUtregner
+            .erUtenforVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding2.sykmelding.id,
+                erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+            ) `should be` false
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding2.sykmelding.id,
+                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
+            }
+    }
+
+    @Test
+    fun `Begge perioder på til sammen 17 dager er utenfor ventetiden`() {
+        val melding1 =
+            lagMottattSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 8),
+            ).also { it.prosesser() }
+
+        val melding2 =
+            lagMottattSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 9),
+                tom = LocalDate.of(2026, Month.JUNE, 17),
+            ).also { it.prosesser() }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding1.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+        ) `should be` true
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding1.sykmelding.id,
+                ventetidRequest = VentetidRequest(),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
+            }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding2.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+        ) `should be` true
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding2.sykmelding.id,
+                ventetidRequest = VentetidRequest(),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
+            }
+    }
+
+    @Test
+    fun `Tilbakedatert bekreftet periode er utenfor ventetiden når alle periode tas med i beregningen`() {
+        lagMottattSykmeldingKafkaMessage(
+            fnr = fnr,
+            fom = LocalDate.of(2026, Month.JUNE, 9),
+            tom = LocalDate.of(2026, Month.JUNE, 17),
+        ).also { it.prosesser() }
+
+        val melding =
+            lagBekreftetSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 8),
+            ).also { it.prosesser() }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+        ) `should be` true
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding.sykmelding.id,
+                ventetidRequest = VentetidRequest(),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
+            }
+    }
+
+    @Test
+    fun `Tilbakedatert bekreftet periode er innenfor ventetiden når kun bekreftet periode tas med i beregningen`() {
+        lagMottattSykmeldingKafkaMessage(
+            fnr = fnr,
+            fom = LocalDate.of(2026, Month.JUNE, 9),
+            tom = LocalDate.of(2026, Month.JUNE, 17),
+        ).also { it.prosesser() }
+
+        val melding =
+            lagBekreftetSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 8),
+            ).also { it.prosesser() }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+        ) `should be` false
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding.sykmelding.id,
+                ventetidRequest = VentetidRequest(kunSendtBekreftet = true, returnerPerioderInnenforVentetid = true),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 8)
+            }
+    }
+
+    @Test
+    fun `Ny sykmelding tas med i ventetidsberegningen når beregnForAktuellSykmelding er true selv om kunSendtBekreftet er true`() {
+        val melding =
+            lagMottattSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 17),
+            ).also { it.prosesser() }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+        ) `should be` false
+
+        // Beholder bitene til den aktuelle sykmeldingen slik at ventetid beregnes i isolasjon.
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+            beregnForAktuellSykmelding = true,
+        ) `should be` true
+    }
+
+    @Test
+    fun `Tilbakedatert bekreftet periode er utenfor ventetiden når det finnes en senere bekreftet periode`() {
+        lagBekreftetSykmeldingKafkaMessage(
+            fnr = fnr,
+            fom = LocalDate.of(2026, Month.JUNE, 9),
+            tom = LocalDate.of(2026, Month.JUNE, 17),
+        ).also { it.prosesser() }
+
+        val melding =
+            lagBekreftetSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 8),
+            ).also { it.prosesser() }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+        ) `should be` true
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding.sykmelding.id,
+                ventetidRequest = VentetidRequest(kunSendtBekreftet = true),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
+            }
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregnerTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregnerTest.kt
@@ -265,7 +265,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` false
 
             hentVentetid(
                 listOf(fnr),
@@ -277,7 +277,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` false
 
             hentVentetid(
                 listOf(fnr),
@@ -308,19 +308,22 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -354,19 +357,22 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -400,19 +406,22 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -446,19 +455,22 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -499,7 +511,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` false
 
             hentVentetid(
                 listOf(fnr),
@@ -511,7 +523,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` false
 
             hentVentetid(
                 listOf(fnr),
@@ -523,7 +535,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding3.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` false
 
             hentVentetid(
                 listOf(fnr),
@@ -561,31 +573,37 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding3.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -626,31 +644,37 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding3.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -684,13 +708,22 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
+
+            hentVentetid(
+                listOf(fnr),
+                sykmeldingId = melding1.sykmelding.id,
+                ventetidRequest = VentetidRequest(),
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -734,7 +767,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -769,19 +802,22 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -816,7 +852,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` false
 
             hentVentetid(
                 listOf(fnr),
@@ -828,7 +864,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` false
 
             hentVentetid(
                 listOf(fnr),
@@ -1018,7 +1054,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
             hentVentetid(
                 sykmeldingId = melding1.sykmelding.id,
                 identer = listOf(fnr),
-                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
+                ventetidRequest = VentetidRequest(),
             ).ventetid!!.also {
                 it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
                 it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 16)
@@ -1028,15 +1064,15 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 melding2.sykmelding.id,
                 ErUtenforVentetidRequest(),
-            ) `should be` false
+            ) `should be` true
 
             hentVentetid(
                 sykmeldingId = melding2.sykmelding.id,
                 identer = listOf(fnr),
-                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
+                ventetidRequest = VentetidRequest(),
             ).ventetid!!.also {
                 it.fom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 1)
-                it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 8)
+                it.tom `should be equal to` LocalDate.of(2025, Month.SEPTEMBER, 16)
             }
         }
     }
@@ -1272,19 +1308,22 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be false`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
                 sykmeldingId = melding1.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).ventetid `should be` null
+            ).ventetid.also {
+                it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
+            }
 
             erUtenforVentetid(
                 listOf(fnr),
                 sykmeldingId = melding2.sykmelding.id,
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            ).`should be true`()
+            ) `should be` true
 
             hentVentetid(
                 listOf(fnr),
@@ -1618,7 +1657,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
             ).ventetid.also {
                 it!!.fom `should be equal to` LocalDate.of(2024, Month.JULY, 1)
-                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 9)
+                it.tom `should be equal to` LocalDate.of(2024, Month.JULY, 16)
             }
 
             erUtenforVentetid(
@@ -1724,7 +1763,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 10)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
@@ -1789,7 +1828,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.JANUARY, 29)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 10)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 13)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
@@ -1841,7 +1880,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 10)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
@@ -1884,7 +1923,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 10)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
@@ -1937,12 +1976,12 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 6)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 13)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmeldingKafkaMessage.sykmelding.id }.also {
@@ -2002,12 +2041,12 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 6)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 13)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmeldingKafkaMessage.sykmelding.id }.also {
@@ -2061,7 +2100,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 10)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
@@ -2071,8 +2110,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding3 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                // 14. og 15. februar er lørdag og søndag og tas derfor ikke med.
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 13)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
         }
 
@@ -2121,7 +2159,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 10)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {
@@ -2131,7 +2169,6 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding3 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                // 14. og 15. februar er lørdag og søndag og tas derfor ikke med.
                 it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
         }
@@ -2231,7 +2268,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
             ventetidperioder.first { it.ressursId == sykmelding1 }.also {
                 it.ventetid.fom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 2)
-                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 10)
+                it.ventetid.tom `should be equal to` LocalDate.of(2026, Month.FEBRUARY, 17)
             }
 
             ventetidperioder.first { it.ressursId == sykmelding2 }.also {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,4 +1,5 @@
 spring:
+  main.banner-mode: 'off'
   profiles:
     active: test,testdatareset
   flyway:
@@ -10,8 +11,9 @@ spring:
 
 management:
   endpoint:
-    prometheus.enabled: true
     health.probes.enabled: true
+    prometheus:
+      access: read_only
   endpoints.web:
     base-path: /internal
     exposure.include: health, prometheus


### PR DESCRIPTION
- Tar med nyere sykmeldigner i beregningen ved beregning av ventetid for
  en tilbakedatert sykmelding sånn at en sykmelding ellers inenfor
  ventetid korrekt blir beregnet til å være utenfor.
- Gjør beregning av ventetid kun på sykmeldinger som er SENDT/BEKREFTET
  for å sikret at sykmeldigner som ikke er sendt inn gjør at en søknad
  ellers innenfor ventetid blir opprettet.
- Beregner ventetid for NY sykmelding hvis kaller kommer fra
  flex-sykmeldinger-backend for å sikret at ventetid alltid kan
  beregnes.
