### PR TITLE
Beregn ventetid kun for SENDT eller BEKREFTET

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
@@ -5,32 +5,27 @@ import java.time.LocalDate
 
 data class ErUtenforVentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
-    val kunSendtBekreftet: Boolean = false,
 )
 
 fun ErUtenforVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding: Boolean = false): VentetidRequest =
     VentetidRequest(
         sykmeldingKafkaMessage = sykmeldingKafkaMessage,
-        kunSendtBekreftet = kunSendtBekreftet,
         beregnForAktuellSykmelding = beregnForAktuellSykmelding,
     )
 
 data class SammeVentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
-    val kunSendtBekreftet: Boolean = false,
 )
 
 fun SammeVentetidRequest.tilVentetidRequest(): VentetidRequest =
     VentetidRequest(
         sykmeldingKafkaMessage = sykmeldingKafkaMessage,
         returnerPerioderInnenforVentetid = true,
-        kunSendtBekreftet = kunSendtBekreftet,
     )
 
 data class VentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
     val returnerPerioderInnenforVentetid: Boolean = false,
-    val kunSendtBekreftet: Boolean = false,
     val beregnForAktuellSykmelding: Boolean = false,
 )
 

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
@@ -48,7 +48,7 @@ class VentetidController(
             ventetidUtregner.erUtenforVentetid(
                 sykmeldingId = sykmeldingId.sanitizeForLog(),
                 identer = hentIdenter(validerTokenXClaims().fnrFraIdportenTokenX()),
-                erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+                erUtenforVentetidRequest = ErUtenforVentetidRequest(),
                 beregnForAktuellSykmelding = true,
             )
         return ErUtenforVentetidResponse(erUtenforVentetid)

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
@@ -82,7 +82,7 @@ class VentetidUtregner(
                 .filter { it.tags.contains(Tag.SYKMELDING) }
                 .filter { bit -> bit.tags.any { tag -> tag in AKTIVITET_TAGS } }
                 .filterNot { bit -> bit.tags.any { it in EKSKLUDERTE_TAGS } }
-                .run { if (ventetidRequest.kunSendtBekreftet) filterNot { it.tags.contains(Tag.NY) } else this }
+                .filterNot { it.tags.contains(Tag.NY) }
                 .map { it.ressursId }
                 .distinct()
                 .toList()
@@ -207,13 +207,12 @@ class VentetidUtregner(
                     addAll(sykmeldingMessage.mapTilBiter())
                 }
             }.let { biter ->
-                // Hvis beregnForAktuellSykmelding er true, beholdes biter med status NY kun for den aktuelle sykmeldingen.
-                // Nødvendig for å beregne ventetid riktig i flex-sykepengesoknad-backend.
-                when {
-                    !ventetidRequest.kunSendtBekreftet -> biter
-                    ventetidRequest.beregnForAktuellSykmelding ->
-                        biter.filterNot { it.tags.contains(Tag.NY) && it.ressursId != sykmeldingId }
-                    else -> biter.filterNot { it.tags.contains(Tag.NY) }
+                // Hvis beregnForAktuellSykmelding er true, tas biter fra den aktuelle sykmeldingen med selv
+                // om den har status NY.
+                if (ventetidRequest.beregnForAktuellSykmelding) {
+                    biter.filterNot { it.tags.contains(Tag.NY) && it.ressursId != sykmeldingId }
+                } else {
+                    biter.filterNot { it.tags.contains(Tag.NY) }
                 }
             }
 

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/OverlappendePerioderTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/OverlappendePerioderTest.kt
@@ -1,7 +1,7 @@
 package no.nav.helse.flex.syketilfelle.ventetid
 
 import no.nav.helse.flex.syketilfelle.FellesTestOppsett
-import no.nav.helse.flex.syketilfelle.lagMottattSykmeldingKafkaMessage
+import no.nav.helse.flex.syketilfelle.lagBekreftetSykmeldingKafkaMessage
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -39,14 +39,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Første og siste periode starter og slutter samtidig`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
@@ -84,14 +84,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 5),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 12),
@@ -129,14 +129,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter samtidig med første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 5),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
@@ -174,14 +174,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter samtidig og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 4),
@@ -219,14 +219,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 3),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 6),
@@ -264,14 +264,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 3),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 6),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
@@ -309,14 +309,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter samtidig og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 4),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
@@ -354,14 +354,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter samtidig med første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 5),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
@@ -399,14 +399,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 5),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 12),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
@@ -447,14 +447,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 15),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
@@ -492,14 +492,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter samtidig med første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 11),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
@@ -537,14 +537,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter samtidig og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
@@ -582,14 +582,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 6),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 13),
@@ -627,14 +627,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 6),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 13),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
@@ -672,14 +672,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter samtidig og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
@@ -717,14 +717,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter samtidig med første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 11),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
@@ -762,14 +762,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 15),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
@@ -810,14 +810,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Første og siste periode starter og slutter samtidig`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
@@ -855,14 +855,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 11),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 28),
@@ -900,14 +900,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter samtidig med første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 5),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
@@ -945,14 +945,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter samtidig og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 5),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
@@ -990,14 +990,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter etter og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 3),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 20),
@@ -1035,14 +1035,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 3),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 20),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
@@ -1080,14 +1080,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter samtidig og slutter etter første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
@@ -1125,14 +1125,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter samtidig med første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 5),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 22),
@@ -1170,14 +1170,14 @@ class OverlappendePerioderTest : FellesTestOppsett() {
         @Test
         fun `Siste periode starter før og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 11),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 28),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 18),

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidControllerTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidControllerTest.kt
@@ -8,7 +8,6 @@ import no.nav.helse.flex.syketilfelle.erUtenforVentetidSomBruker
 import no.nav.helse.flex.syketilfelle.finnPerioderMedSammeVentetid
 import no.nav.helse.flex.syketilfelle.finnPerioderMedSammeVentetidSomBruker
 import no.nav.helse.flex.syketilfelle.lagBekreftetSykmeldingKafkaMessage
-import no.nav.helse.flex.syketilfelle.lagMottattSykmeldingKafkaMessage
 import no.nav.helse.flex.syketilfelle.lagSyketilfelleBit
 import no.nav.helse.flex.syketilfelle.objectMapper
 import no.nav.helse.flex.syketilfelle.syketilfellebit.Tag
@@ -113,7 +112,7 @@ class VentetidControllerTest : FellesTestOppsett() {
     @Test
     fun `Periode på 16 dager er innefor ventetiden som bruker`() {
         val melding =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 1),
                 tom = LocalDate.of(2024, Month.JULY, 16),
@@ -130,7 +129,7 @@ class VentetidControllerTest : FellesTestOppsett() {
     @Test
     fun `Periode på 17 dager er utenfor ventetiden som bruker`() {
         val melding =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 1),
                 tom = LocalDate.of(2024, Month.JULY, 17),
@@ -198,7 +197,7 @@ class VentetidControllerTest : FellesTestOppsett() {
     @Test
     fun `Kall til perioderMedSammeVentetid som bruker returnerer riktig periode`() {
         val melding =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                 tom = LocalDate.of(2026, Month.FEBRUARY, 17),
@@ -223,7 +222,7 @@ class VentetidControllerTest : FellesTestOppsett() {
     @Test
     fun `Kall til perioderMedSammeVentetid returnerer riktig periode`() {
         val melding =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                 tom = LocalDate.of(2026, Month.FEBRUARY, 17),
@@ -248,7 +247,7 @@ class VentetidControllerTest : FellesTestOppsett() {
     @Test
     fun `Kall til perioderMedSammeVentetid returnerer tom liste hvis fnr ikke matcher biter`() {
         val melding =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                 tom = LocalDate.of(2026, Month.FEBRUARY, 17),

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidKunSendtBekreftetTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidKunSendtBekreftetTest.kt
@@ -27,64 +27,6 @@ class VentetidKunSendtBekreftetTest : FellesTestOppsett() {
     private val fnr = "11111111111"
 
     @Test
-    fun `Beregn ventetid for alle sykmeldinger`() {
-        val mottattSykmelding =
-            lagMottattSykmeldingKafkaMessage(
-                fnr = fnr,
-                fom = LocalDate.of(2026, Month.JUNE, 1),
-                tom = LocalDate.of(2026, Month.JUNE, 7),
-            ).also { it.prosesser() }
-
-        val bekreftetSykmelding =
-            lagBekreftetSykmeldingKafkaMessage(
-                fnr = fnr,
-                fom = LocalDate.of(2026, Month.JUNE, 8),
-                tom = LocalDate.of(2026, Month.JUNE, 14),
-            ).also { it.prosesser() }
-
-        val sendtSykmelding =
-            lagSendtSykmeldingKafkaMessage(
-                fnr,
-                lagArbeidsgiverSykmelding(
-                    fom = LocalDate.of(2026, Month.JUNE, 15),
-                    tom = LocalDate.of(2026, Month.JUNE, 21),
-                ),
-            ).also { it.prosesser() }
-
-        ventetidUtregner.erUtenforVentetid(
-            sykmeldingId = sendtSykmelding.sykmelding.id,
-            identer = listOf(fnr),
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-        ) `should be` true
-
-        ventetidUtregner
-            .beregnVentetid(
-                identer = listOf(fnr),
-                sykmeldingId = sendtSykmelding.sykmelding.id,
-                ventetidRequest = VentetidRequest(),
-            ).also {
-                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
-                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
-            }
-
-        ventetidUtregner
-            .finnPerioderMedSammeVentetid(
-                identer = listOf(fnr),
-                sykmeldingId = sendtSykmelding.sykmelding.id,
-                sammeVentetidRequest = SammeVentetidRequest(),
-            ).also { response ->
-                response.size `should be` 3
-                response.map { it.ressursId }.containsAll(
-                    listOf(
-                        mottattSykmelding.sykmelding.id,
-                        bekreftetSykmelding.sykmelding.id,
-                        sendtSykmelding.sykmelding.id,
-                    ),
-                )
-            }
-    }
-
-    @Test
     fun `Beregn ventetid for perioder kun sendt eller bekreftet`() {
         lagMottattSykmeldingKafkaMessage(
             fnr = fnr,
@@ -111,14 +53,14 @@ class VentetidKunSendtBekreftetTest : FellesTestOppsett() {
         ventetidUtregner.erUtenforVentetid(
             sykmeldingId = sendtSykmelding.sykmelding.id,
             identer = listOf(fnr),
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
         ) `should be` false
 
         ventetidUtregner
             .beregnVentetid(
                 identer = listOf(fnr),
                 sykmeldingId = sendtSykmelding.sykmelding.id,
-                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true, kunSendtBekreftet = true),
+                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
             ).also {
                 it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 8)
                 it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 19)
@@ -128,7 +70,7 @@ class VentetidKunSendtBekreftetTest : FellesTestOppsett() {
             .finnPerioderMedSammeVentetid(
                 identer = listOf(fnr),
                 sykmeldingId = sendtSykmelding.sykmelding.id,
-                sammeVentetidRequest = SammeVentetidRequest(kunSendtBekreftet = true),
+                sammeVentetidRequest = SammeVentetidRequest(),
             ).also { response ->
                 response.size `should be` 2
                 response.map { it.ressursId }.containsAll(
@@ -164,14 +106,14 @@ class VentetidKunSendtBekreftetTest : FellesTestOppsett() {
         ventetidUtregner.erUtenforVentetid(
             sykmeldingId = melding.sykmelding.id,
             identer = listOf(fnr),
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
         ) `should be` false
 
         ventetidUtregner
             .beregnVentetid(
                 identer = listOf(fnr),
                 sykmeldingId = melding.sykmelding.id,
-                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true, kunSendtBekreftet = true),
+                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
             ).also {
                 it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 11)
                 it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 19)
@@ -181,7 +123,7 @@ class VentetidKunSendtBekreftetTest : FellesTestOppsett() {
             .finnPerioderMedSammeVentetid(
                 identer = listOf(fnr),
                 sykmeldingId = melding.sykmelding.id,
-                sammeVentetidRequest = SammeVentetidRequest(kunSendtBekreftet = true),
+                sammeVentetidRequest = SammeVentetidRequest(),
             ).also { response ->
                 response.size `should be` 1
                 response.map { it.ressursId }.containsAll(

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidTilbakedateringTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidTilbakedateringTest.kt
@@ -27,14 +27,14 @@ class VentetidTilbakedateringTest : FellesTestOppsett() {
     @Test
     fun `To perioder til sammen 16 dager har samme ventetid`() {
         val melding1 =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2026, Month.JUNE, 1),
                 tom = LocalDate.of(2026, Month.JUNE, 8),
             ).also { it.prosesser() }
 
         val melding2 =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2026, Month.JUNE, 9),
                 tom = LocalDate.of(2026, Month.JUNE, 16),
@@ -78,14 +78,14 @@ class VentetidTilbakedateringTest : FellesTestOppsett() {
     @Test
     fun `Begge perioder på til sammen 17 dager er utenfor ventetiden`() {
         val melding1 =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2026, Month.JUNE, 1),
                 tom = LocalDate.of(2026, Month.JUNE, 8),
             ).also { it.prosesser() }
 
         val melding2 =
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2026, Month.JUNE, 9),
                 tom = LocalDate.of(2026, Month.JUNE, 17),
@@ -125,8 +125,64 @@ class VentetidTilbakedateringTest : FellesTestOppsett() {
     }
 
     @Test
-    fun `Tilbakedatert bekreftet periode er utenfor ventetiden når alle periode tas med i beregningen`() {
+    fun `Tilbakedatert bekreftet periode er innenfor ventetiden når kun bekreftet periode tas med i beregningen`() {
         lagMottattSykmeldingKafkaMessage(
+            fnr = fnr,
+            fom = LocalDate.of(2026, Month.JUNE, 9),
+            tom = LocalDate.of(2026, Month.JUNE, 17),
+        ).also { it.prosesser() }
+
+        val melding =
+            lagBekreftetSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 8),
+            ).also { it.prosesser() }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+        ) `should be` false
+
+        ventetidUtregner
+            .beregnVentetid(
+                identer = listOf(fnr),
+                sykmeldingId = melding.sykmelding.id,
+                ventetidRequest = VentetidRequest(returnerPerioderInnenforVentetid = true),
+            ).also {
+                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
+                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 8)
+            }
+    }
+
+    @Test
+    fun `Ny sykmelding tas med i ventetidsberegningen når beregnForAktuellSykmelding er true selv om kunSendtBekreftet er true`() {
+        val melding =
+            lagMottattSykmeldingKafkaMessage(
+                fnr = fnr,
+                fom = LocalDate.of(2026, Month.JUNE, 1),
+                tom = LocalDate.of(2026, Month.JUNE, 17),
+            ).also { it.prosesser() }
+
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+        ) `should be` false
+
+        // Beholder bitene til den aktuelle sykmeldingen slik at ventetid beregnes i isolasjon.
+        ventetidUtregner.erUtenforVentetid(
+            identer = listOf(fnr),
+            sykmeldingId = melding.sykmelding.id,
+            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
+            beregnForAktuellSykmelding = true,
+        ) `should be` true
+    }
+
+    @Test
+    fun `Tilbakedatert bekreftet periode er utenfor ventetiden når det finnes en senere bekreftet periode`() {
+        lagBekreftetSykmeldingKafkaMessage(
             fnr = fnr,
             fom = LocalDate.of(2026, Month.JUNE, 9),
             tom = LocalDate.of(2026, Month.JUNE, 17),
@@ -150,94 +206,6 @@ class VentetidTilbakedateringTest : FellesTestOppsett() {
                 identer = listOf(fnr),
                 sykmeldingId = melding.sykmelding.id,
                 ventetidRequest = VentetidRequest(),
-            ).also {
-                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
-                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)
-            }
-    }
-
-    @Test
-    fun `Tilbakedatert bekreftet periode er innenfor ventetiden når kun bekreftet periode tas med i beregningen`() {
-        lagMottattSykmeldingKafkaMessage(
-            fnr = fnr,
-            fom = LocalDate.of(2026, Month.JUNE, 9),
-            tom = LocalDate.of(2026, Month.JUNE, 17),
-        ).also { it.prosesser() }
-
-        val melding =
-            lagBekreftetSykmeldingKafkaMessage(
-                fnr = fnr,
-                fom = LocalDate.of(2026, Month.JUNE, 1),
-                tom = LocalDate.of(2026, Month.JUNE, 8),
-            ).also { it.prosesser() }
-
-        ventetidUtregner.erUtenforVentetid(
-            identer = listOf(fnr),
-            sykmeldingId = melding.sykmelding.id,
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
-        ) `should be` false
-
-        ventetidUtregner
-            .beregnVentetid(
-                identer = listOf(fnr),
-                sykmeldingId = melding.sykmelding.id,
-                ventetidRequest = VentetidRequest(kunSendtBekreftet = true, returnerPerioderInnenforVentetid = true),
-            ).also {
-                it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
-                it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 8)
-            }
-    }
-
-    @Test
-    fun `Ny sykmelding tas med i ventetidsberegningen når beregnForAktuellSykmelding er true selv om kunSendtBekreftet er true`() {
-        val melding =
-            lagMottattSykmeldingKafkaMessage(
-                fnr = fnr,
-                fom = LocalDate.of(2026, Month.JUNE, 1),
-                tom = LocalDate.of(2026, Month.JUNE, 17),
-            ).also { it.prosesser() }
-
-        ventetidUtregner.erUtenforVentetid(
-            identer = listOf(fnr),
-            sykmeldingId = melding.sykmelding.id,
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
-        ) `should be` false
-
-        // Beholder bitene til den aktuelle sykmeldingen slik at ventetid beregnes i isolasjon.
-        ventetidUtregner.erUtenforVentetid(
-            identer = listOf(fnr),
-            sykmeldingId = melding.sykmelding.id,
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
-            beregnForAktuellSykmelding = true,
-        ) `should be` true
-    }
-
-    @Test
-    fun `Tilbakedatert bekreftet periode er utenfor ventetiden når det finnes en senere bekreftet periode`() {
-        lagBekreftetSykmeldingKafkaMessage(
-            fnr = fnr,
-            fom = LocalDate.of(2026, Month.JUNE, 9),
-            tom = LocalDate.of(2026, Month.JUNE, 17),
-        ).also { it.prosesser() }
-
-        val melding =
-            lagBekreftetSykmeldingKafkaMessage(
-                fnr = fnr,
-                fom = LocalDate.of(2026, Month.JUNE, 1),
-                tom = LocalDate.of(2026, Month.JUNE, 8),
-            ).also { it.prosesser() }
-
-        ventetidUtregner.erUtenforVentetid(
-            identer = listOf(fnr),
-            sykmeldingId = melding.sykmelding.id,
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(kunSendtBekreftet = true),
-        ) `should be` true
-
-        ventetidUtregner
-            .beregnVentetid(
-                identer = listOf(fnr),
-                sykmeldingId = melding.sykmelding.id,
-                ventetidRequest = VentetidRequest(kunSendtBekreftet = true),
             ).also {
                 it!!.fom `should be equal to` LocalDate.of(2026, Month.JUNE, 1)
                 it.tom `should be equal to` LocalDate.of(2026, Month.JUNE, 16)

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregnerTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregnerTest.kt
@@ -2,7 +2,6 @@ package no.nav.helse.flex.syketilfelle.ventetid
 
 import no.nav.helse.flex.syketilfelle.FellesTestOppsett
 import no.nav.helse.flex.syketilfelle.lagBekreftetSykmeldingKafkaMessage
-import no.nav.helse.flex.syketilfelle.lagMottattSykmeldingKafkaMessage
 import no.nav.helse.flex.syketilfelle.lagSyketilfelleBit
 import no.nav.helse.flex.syketilfelle.syketilfellebit.Tag
 import no.nav.syfo.model.sykmelding.arbeidsgiver.SykmeldingsperiodeAGDTO
@@ -246,14 +245,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen 16 dager er innenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 9),
                     tom = LocalDate.of(2024, Month.JULY, 16),
@@ -289,14 +288,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen 17 dager er utenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 8),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 9),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -338,14 +337,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen over 16 dager med lørdag mellom er utenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 12),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 14),
                     tom = LocalDate.of(2024, Month.JULY, 21),
@@ -387,14 +386,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen over 16 dager med søndag mellom er utenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 13),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 15),
                     tom = LocalDate.of(2024, Month.JULY, 21),
@@ -436,14 +435,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen over 16 dager med lørdag og søndag mellom er utenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 12),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 15),
                     tom = LocalDate.of(2024, Month.JULY, 21),
@@ -485,21 +484,21 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Tre perioder til sammen 16 dager er innenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 5),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 6),
                     tom = LocalDate.of(2024, Month.JULY, 10),
                 ).also { it.prosesser() }
 
             val melding3 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 11),
                     tom = LocalDate.of(2024, Month.JULY, 16),
@@ -547,21 +546,21 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Tre perioder til sammen 17 dager er utenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 5),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 6),
                     tom = LocalDate.of(2024, Month.JULY, 10),
                 ).also { it.prosesser() }
 
             val melding3 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 11),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -618,21 +617,21 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Tre perioder til sammen over 16 dager på grunn av helg er utenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 5),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 6),
                     tom = LocalDate.of(2024, Month.JULY, 12),
                 ).also { it.prosesser() }
 
             val melding3 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 14),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -689,14 +688,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen 17 dager og siste periode er én dag lang er utenfor ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 16),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 17),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -738,7 +737,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder i samme sykmelding merges likt perioder fra to sykmeldinger`() {
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 16),
@@ -782,7 +781,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen 17 dager er utenfor ventetiden når første periode har tag REISETILSKUDD`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 8),
@@ -790,7 +789,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 9),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -832,7 +831,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen 17 dager er innenfor ventetiden når første periode har tag AVVENTENDE`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 8),
@@ -840,7 +839,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 9),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -885,14 +884,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
     inner class OppholdMellomPerioder {
         @Test
         fun `Kort periode påvirker ikke kort periode selv om opphold er kortere enn 17 dager`() {
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 1),
                 tom = LocalDate.of(2024, Month.JULY, 16),
             ).also { it.prosesser() }
 
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 18),
                     tom = LocalDate.of(2024, Month.JULY, 31),
@@ -909,14 +908,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
         @Test
         fun `Kort periode påvirker ikke lang periode selv om opphold er kortere enn 17 dager`() {
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 1),
                 tom = LocalDate.of(2024, Month.JULY, 10),
             ).also { it.prosesser() }
 
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 12),
                     tom = LocalDate.of(2024, Month.JULY, 31),
@@ -942,14 +941,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
         @Test
         fun `Lang periode påvirker kort periode teller hvis opphold er kortere enn 17 dager`() {
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 1),
                 tom = LocalDate.of(2024, Month.JULY, 17),
             ).also { it.prosesser() }
 
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 21),
                     tom = LocalDate.of(2024, Month.JULY, 31),
@@ -976,14 +975,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
         @Test
         fun `Lang periode påvirker ikke neste periode hvis opphold er lengre enn 16 dager`() {
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 1),
                 tom = LocalDate.of(2024, Month.JULY, 17),
             ).also { it.prosesser() }
 
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.AUGUST, 3),
                     tom = LocalDate.of(2024, Month.AUGUST, 16),
@@ -1004,13 +1003,13 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Siste sykmelding har flere periode og starter samtidig og slutter før første periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 1),
                     tom = LocalDate.of(2025, Month.SEPTEMBER, 30),
                 ).also { it.prosesser() }
 
-            val sykmeldingKafkaMessage = lagMottattSykmeldingKafkaMessage(fnr)
+            val sykmeldingKafkaMessage = lagBekreftetSykmeldingKafkaMessage(fnr)
 
             val melding2 =
                 sykmeldingKafkaMessage
@@ -1207,7 +1206,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
         @Test
         fun `Egenmeldingsdager mellom to perioder som svar tas ikke med i ventetiden`() {
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2025, Month.JULY, 9),
                 tom = LocalDate.of(2025, Month.JULY, 25),
@@ -1288,7 +1287,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Periode med behandlingsdager før tas med i beregningen`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 8),
@@ -1296,7 +1295,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 9),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -1337,20 +1336,20 @@ class VentetidUtregnerTest : FellesTestOppsett() {
 
         @Test
         fun `Periode med behandlinsdag etter tas med i beregningen`() {
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 1),
                 tom = LocalDate.of(2024, Month.JULY, 8),
             ).also { it.prosesser() }
 
-            lagMottattSykmeldingKafkaMessage(
+            lagBekreftetSykmeldingKafkaMessage(
                 fnr = fnr,
                 fom = LocalDate.of(2024, Month.JULY, 9),
                 tom = LocalDate.of(2024, Month.JULY, 16),
             ).also { it.prosesser() }
 
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 17),
                     tom = LocalDate.of(2024, Month.JULY, 22),
@@ -1381,7 +1380,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Lang Avventede Sykmelding påvirker ikke ventetiden`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 17),
@@ -1389,7 +1388,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 18),
                     tom = LocalDate.of(2024, Month.JULY, 30),
@@ -1433,7 +1432,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Periode på 16 returnerer ventetid lik perioden`() {
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 16),
@@ -1460,7 +1459,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Periode på 1 dag returnerer ventetid lik perioden`() {
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 1),
@@ -1487,7 +1486,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Periode som slutter på lørdag returnerer én dag kortere ventetid enn perioden`() {
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 6),
@@ -1559,7 +1558,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Periode normalt utenfor ventetiden påvirkes ikke av 'returnerPerioderInnenforVentetid'`() {
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 31),
@@ -1586,7 +1585,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `Siste periode av to perioder i samme sykmelding brukes når periodene ikke kan merges`() {
             val melding =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 9),
@@ -1630,14 +1629,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         @Test
         fun `To perioder til sammen 16 dager returnerer ventetid lik merget periode`() {
             val melding1 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 1),
                     tom = LocalDate.of(2024, Month.JULY, 9),
                 ).also { it.prosesser() }
 
             val melding2 =
-                lagMottattSykmeldingKafkaMessage(
+                lagBekreftetSykmeldingKafkaMessage(
                     fnr = fnr,
                     fom = LocalDate.of(2024, Month.JULY, 10),
                     tom = LocalDate.of(2024, Month.JULY, 16),
@@ -1692,7 +1691,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                     tags =
                         listOf(
                             Tag.SYKMELDING,
-                            Tag.NY,
+                            Tag.BEKREFTET,
                             Tag.PERIODE,
                             Tag.INGEN_AKTIVITET,
                             Tag.REDUSERT_ARBEIDSGIVERPERIODE,
@@ -1703,7 +1702,7 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                     ressursId = sykmeldingId,
                     fom = LocalDate.of(2025, Month.SEPTEMBER, 10),
                     tom = LocalDate.of(2025, Month.OCTOBER, 13),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
             ).also { syketilfellebitRepository.saveAll(it) }
 
@@ -1732,14 +1731,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                     ressursId = sykmelding1,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 10),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
                 lagSyketilfelleBit(
                     fnr = fnr,
                     ressursId = sykmelding2,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 11),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 22),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
                 lagSyketilfelleBit(
                     fnr = fnr,
@@ -1783,14 +1782,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                     ressursId = sykmelding1,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 10),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
                 lagSyketilfelleBit(
                     fnr = fnr,
                     ressursId = sykmelding2,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 11),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 22),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
                 lagSyketilfelleBit(
                     fnr = fnr,
@@ -2244,14 +2243,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                     ressursId = sykmelding1,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 10),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.REISETILSKUDD, Tag.UKJENT_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.REISETILSKUDD, Tag.UKJENT_AKTIVITET),
                 ),
                 lagSyketilfelleBit(
                     fnr = fnr,
                     ressursId = sykmelding2,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 11),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 22),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
             ).also { syketilfellebitRepository.saveAll(it) }
 
@@ -2288,14 +2287,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                     ressursId = sykmelding1,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 10),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.AVVENTENDE),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.AVVENTENDE),
                 ),
                 lagSyketilfelleBit(
                     fnr = fnr,
                     ressursId = sykmelding2,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 11),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 22),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
             ).also { syketilfellebitRepository.saveAll(it) }
 
@@ -2327,14 +2326,14 @@ class VentetidUtregnerTest : FellesTestOppsett() {
                     ressursId = sykmelding1,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 2),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 10),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.INGEN_AKTIVITET),
                 ),
                 lagSyketilfelleBit(
                     fnr = fnr,
                     ressursId = sykmelding2,
                     fom = LocalDate.of(2026, Month.FEBRUARY, 11),
                     tom = LocalDate.of(2026, Month.FEBRUARY, 22),
-                    tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.AVVENTENDE),
+                    tags = listOf(Tag.SYKMELDING, Tag.BEKREFTET, Tag.PERIODE, Tag.AVVENTENDE),
                 ),
             ).also { syketilfellebitRepository.saveAll(it) }
 


### PR DESCRIPTION
Beregner alltid ventetid på perioder som har status SENDT eller BEKREFTET
med mindre beregnForAktuellSykmelding er angitt. Da tas også aktuell
sykmelding med selv om den har status NY.

- Gjort funksjonalitet tidligere styrt av kunSendtBekrefet til default funksjonalitet.
- Slettet unødvendige tester
