### PR TITLE
Ta alltid med aktuell sykmelding i beregning av ventetid

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
@@ -16,11 +16,10 @@ data class SammeVentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
 )
 
-fun SammeVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding: Boolean): VentetidRequest =
+fun SammeVentetidRequest.tilVentetidRequest(): VentetidRequest =
     VentetidRequest(
         sykmeldingKafkaMessage = sykmeldingKafkaMessage,
         returnerPerioderInnenforVentetid = true,
-        beregnForAktuellSykmelding = beregnForAktuellSykmelding,
     )
 
 data class VentetidRequest(

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
@@ -7,10 +7,9 @@ data class ErUtenforVentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
 )
 
-fun ErUtenforVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding: Boolean = false): VentetidRequest =
+fun ErUtenforVentetidRequest.tilVentetidRequest(): VentetidRequest =
     VentetidRequest(
         sykmeldingKafkaMessage = sykmeldingKafkaMessage,
-        beregnForAktuellSykmelding = beregnForAktuellSykmelding,
     )
 
 data class SammeVentetidRequest(
@@ -27,7 +26,6 @@ fun SammeVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding: Boolean)
 data class VentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
     val returnerPerioderInnenforVentetid: Boolean = false,
-    val beregnForAktuellSykmelding: Boolean = false,
 )
 
 data class VentetidResponse(

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/Ventetid.kt
@@ -17,10 +17,11 @@ data class SammeVentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessage? = null,
 )
 
-fun SammeVentetidRequest.tilVentetidRequest(): VentetidRequest =
+fun SammeVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding: Boolean): VentetidRequest =
     VentetidRequest(
         sykmeldingKafkaMessage = sykmeldingKafkaMessage,
         returnerPerioderInnenforVentetid = true,
+        beregnForAktuellSykmelding = beregnForAktuellSykmelding,
     )
 
 data class VentetidRequest(

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
@@ -49,7 +49,6 @@ class VentetidController(
                 sykmeldingId = sykmeldingId.sanitizeForLog(),
                 identer = hentIdenter(validerTokenXClaims().fnrFraIdportenTokenX()),
                 erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-                beregnForAktuellSykmelding = true,
             )
         return ErUtenforVentetidResponse(erUtenforVentetid)
     }

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
@@ -92,7 +92,6 @@ class VentetidController(
                     sanitertSykmeldingId,
                     identer,
                     SammeVentetidRequest(),
-                    true,
                 ),
         )
     }

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidController.kt
@@ -93,6 +93,7 @@ class VentetidController(
                     sanitertSykmeldingId,
                     identer,
                     SammeVentetidRequest(),
+                    true,
                 ),
         )
     }

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
@@ -58,8 +58,9 @@ class VentetidUtregner(
         sykmeldingId: String,
         identer: List<String>,
         sammeVentetidRequest: SammeVentetidRequest,
+        beregnForAktuellSykmelding: Boolean = false,
     ): List<SammeVentetidPeriode> {
-        val ventetidRequest = sammeVentetidRequest.tilVentetidRequest()
+        val ventetidRequest = sammeVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding)
 
         // Sender med VentetidRequest i tilfelle Kafka-meldingen ikke er lagret enda.
         val sykmeldingVentetid =

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
@@ -57,9 +57,8 @@ class VentetidUtregner(
         sykmeldingId: String,
         identer: List<String>,
         sammeVentetidRequest: SammeVentetidRequest,
-        beregnForAktuellSykmelding: Boolean = false,
     ): List<SammeVentetidPeriode> {
-        val ventetidRequest = sammeVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding)
+        val ventetidRequest = sammeVentetidRequest.tilVentetidRequest()
 
         // Sender med VentetidRequest i tilfelle Kafka-meldingen ikke er lagret enda.
         val sykmeldingVentetid =

--- a/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
+++ b/src/main/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregner.kt
@@ -51,8 +51,7 @@ class VentetidUtregner(
         sykmeldingId: String,
         identer: List<String>,
         erUtenforVentetidRequest: ErUtenforVentetidRequest,
-        beregnForAktuellSykmelding: Boolean = false,
-    ): Boolean = beregnVentetid(sykmeldingId, identer, erUtenforVentetidRequest.tilVentetidRequest(beregnForAktuellSykmelding)) != null
+    ): Boolean = beregnVentetid(sykmeldingId, identer, erUtenforVentetidRequest.tilVentetidRequest()) != null
 
     fun finnPerioderMedSammeVentetid(
         sykmeldingId: String,
@@ -83,7 +82,7 @@ class VentetidUtregner(
                 .filter { it.tags.contains(Tag.SYKMELDING) }
                 .filter { bit -> bit.tags.any { tag -> tag in AKTIVITET_TAGS } }
                 .filterNot { bit -> bit.tags.any { it in EKSKLUDERTE_TAGS } }
-                .filterNot { it.tags.contains(Tag.NY) }
+                .filterNot { it.tags.contains(Tag.NY) && it.ressursId != sykmeldingId }
                 .map { it.ressursId }
                 .distinct()
                 .toList()
@@ -192,9 +191,9 @@ class VentetidUtregner(
 
     private fun Periode.erLengreEnnVentetiden(): Boolean = DAYS.between(this.fom, this.tom) >= SEKSTEN_DAGER
 
-    // Kombinerer eksisterende syketilfellebiter med nye biter fra sykmeldingen og eventuelle tilleggsopplysninger (som
-    // egenmeldinger) fra forespørselen. Det kan resulterer i duplikate biter hvis den aktuelle sykmeldignen både er
-    // lagret i databasen og sendt med i sykmeldingKafkaMessage. Duplikate biter blir slått sammen i mergePerioder().
+    // Kombinerer eksisterende syketilfellebiter med nye biter fra sykmeldingen og eventuelle egenmeldingsdager fra request.
+    // Det kan resulterer i duplikate biter hvis den aktuelle sykmeldingen både er lagret i databasen og sendt med i
+    // sykmeldingKafkaMessage. Duplikate biter blir slått sammen i mergePerioder().
     private fun lagSykmeldingBiter(
         eksisterendeBiter: List<Syketilfellebit>,
         sykmeldingId: String,
@@ -208,13 +207,7 @@ class VentetidUtregner(
                     addAll(sykmeldingMessage.mapTilBiter())
                 }
             }.let { biter ->
-                // Hvis beregnForAktuellSykmelding er true, tas biter fra den aktuelle sykmeldingen med selv
-                // om den har status NY.
-                if (ventetidRequest.beregnForAktuellSykmelding) {
-                    biter.filterNot { it.tags.contains(Tag.NY) && it.ressursId != sykmeldingId }
-                } else {
-                    biter.filterNot { it.tags.contains(Tag.NY) }
-                }
+                biter.filterNot { it.tags.contains(Tag.NY) && it.ressursId != sykmeldingId }
             }
 
     private fun Syketilfellebit.tilPeriode(): Periode =

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidTilbakedateringTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidTilbakedateringTest.kt
@@ -157,30 +157,6 @@ class VentetidTilbakedateringTest : FellesTestOppsett() {
     }
 
     @Test
-    fun `Ny sykmelding tas med i ventetidsberegningen når beregnForAktuellSykmelding er true selv om kunSendtBekreftet er true`() {
-        val melding =
-            lagMottattSykmeldingKafkaMessage(
-                fnr = fnr,
-                fom = LocalDate.of(2026, Month.JUNE, 1),
-                tom = LocalDate.of(2026, Month.JUNE, 17),
-            ).also { it.prosesser() }
-
-        ventetidUtregner.erUtenforVentetid(
-            identer = listOf(fnr),
-            sykmeldingId = melding.sykmelding.id,
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-        ) `should be` false
-
-        // Beholder bitene til den aktuelle sykmeldingen slik at ventetid beregnes i isolasjon.
-        ventetidUtregner.erUtenforVentetid(
-            identer = listOf(fnr),
-            sykmeldingId = melding.sykmelding.id,
-            erUtenforVentetidRequest = ErUtenforVentetidRequest(),
-            beregnForAktuellSykmelding = true,
-        ) `should be` true
-    }
-
-    @Test
     fun `Tilbakedatert bekreftet periode er utenfor ventetiden når det finnes en senere bekreftet periode`() {
         lagBekreftetSykmeldingKafkaMessage(
             fnr = fnr,

--- a/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregnerTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/syketilfelle/ventetid/VentetidUtregnerTest.kt
@@ -2346,6 +2346,28 @@ class VentetidUtregnerTest : FellesTestOppsett() {
         }
     }
 
+    @Test
+    fun `Solo sykmelding skal returneres`() {
+        val sykmelding1 = UUID.randomUUID().toString()
+
+        listOf(
+            lagSyketilfelleBit(
+                fnr = fnr,
+                ressursId = sykmelding1,
+                fom = LocalDate.of(2026, Month.MAY, 13),
+                tom = LocalDate.of(2026, Month.MAY, 20),
+                tags = listOf(Tag.SYKMELDING, Tag.NY, Tag.PERIODE, Tag.INGEN_AKTIVITET),
+            ),
+        ).also { syketilfellebitRepository.saveAll(it) }
+
+        ventetidUtregner
+            .finnPerioderMedSammeVentetid(
+                sykmelding1,
+                listOf(fnr),
+                SammeVentetidRequest(),
+            ).size `should be` 1
+    }
+
     private fun erUtenforVentetid(
         identer: List<String>,
         sykmeldingId: String,


### PR DESCRIPTION
Fjerner behovet for å sende eget flagg ved request fra flex-sykmeldinger-backend for sikret at ventetid for aktuell sykmelding med status NY alltid blir beregnet.
